### PR TITLE
Add FF-style keyboard navigation across the whole game

### DIFF
--- a/src/app/components/Board/Board.module.scss
+++ b/src/app/components/Board/Board.module.scss
@@ -143,7 +143,9 @@
     }
 
 
-    [data-focused=true] {
+    // div[data-position] prefix keeps this more specific than the generic
+    // full-size ::before/::after cell overlays above
+    div[data-position][data-focused=true] {
         &::after {
             content: "";
             position: absolute;

--- a/src/app/components/Board/Board.module.scss
+++ b/src/app/components/Board/Board.module.scss
@@ -143,8 +143,8 @@
     }
 
 
-    [data-selectable=true] {
-        &:hover::after {
+    [data-focused=true] {
+        &::after {
             content: "";
             position: absolute;
             margin-left: 16px;

--- a/src/app/components/Board/Board.tsx
+++ b/src/app/components/Board/Board.tsx
@@ -523,7 +523,8 @@ const Board: React.FC<BoardProps> = ({ className }) => {
         };
     }, [focus]);
 
-    // After a placement (or any deselect) the cursor returns to the hand
+    // After a placement (or any deselect) the cursor returns to the hand;
+    // the visible hand cursor only renders on the player's own turn
     useEffect(() => {
         if (selectedCardId || pos?.group !== "board") return;
         if (currentPlayerHand.length === 0) {
@@ -533,7 +534,7 @@ const Board: React.FC<BoardProps> = ({ className }) => {
         }
         const index = Math.min(lastHandIndexRef.current, currentPlayerHand.length - 1);
         setPosSilently({ group: "hand", index });
-        gameNav.setFocus({ player: "blue", index });
+        gameNav.setFocus((turn === "blue") ? { player: "blue", index } : null);
     }, [selectedCardId]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Keyboard-started games begin with the cursor on the first hand card
@@ -552,6 +553,8 @@ const Board: React.FC<BoardProps> = ({ className }) => {
 
     useEffect(() => {
         if (turn === "red" && turnNumber <= ((debug) ? 1 : 9)) {
+            // The player's cursor hides while the AI takes its turn
+            gameNav.setFocus(null);
             const enemyMove = getEnemyMove(board, currentEnemyHand, "advanced", elements);
             if (enemyMove) {
                 const { enemyCardId, enemyPosition, uniqueId } = enemyMove;

--- a/src/app/components/Board/Board.tsx
+++ b/src/app/components/Board/Board.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import styles from './Board.module.scss';
 import Card from '../Card/Card';
 import cards from '../../../data/cards.json';
@@ -13,6 +13,8 @@ import playSound from "../../utils/sounds";
 import textToSprite from '../../utils/textToSprite';
 import elementsList from "../../../data/elements.json";
 import BoardMessage from "../BoardMessage/BoardMessage";
+import { useCursorNav, consumeKeyboardNavIntent } from "../../hooks/useCursorNav";
+import { gameNav } from "../../hooks/gameNav";
 
 interface BoardProps {
     className?: string;
@@ -20,7 +22,7 @@ interface BoardProps {
 
 const Board: React.FC<BoardProps> = ({ className }) => {
     const debug = false;
-    const { currentPlayerHand, currentEnemyHand, selectedCardId, turn, turnNumber, turnState, score, board, isGameActive, isSoundEnabled, rules, elements, winState, dispatch } = useGameContext();
+    const { currentPlayerHand, currentEnemyHand, selectedCardId, turn, turnNumber, turnState, score, board, isGameActive, isSoundEnabled, rules, elements, winState, isMenuOpen, isCardSelectionOpen, isCardGalleryOpen, isRewardSelectionOpen, dispatch } = useGameContext();
     const [sameFlag, setSameFlag] = useState(false);
     const [plusFlag, setPlusFlag] = useState(false);
     const [comboFlag, setComboFlag] = useState(false);
@@ -434,9 +436,118 @@ const Board: React.FC<BoardProps> = ({ className }) => {
 
     const handleMouseEnter = (rowIndex: number, colIndex: number) => {
         if (!board[rowIndex][colIndex] && !!selectedCardId && turn === "blue") {
-            playSound("select", isSoundEnabled);
+            focus({ group: "board", index: rowIndex * 3 + colIndex });
         }
     }
+
+    const lastHandIndexRef = useRef(0);
+    const lastBoardCellRef = useRef<number | null>(null);
+    const posRef = useRef<{ group: string; index: number } | null>(null);
+    // The cell the AI's cursor hovers before it places a card
+    const [aiBoardCell, setAiBoardCell] = useState<number | null>(null);
+
+    const firstPlacementCell = () => {
+        if (lastBoardCellRef.current !== null) {
+            const row = Math.floor(lastBoardCellRef.current / 3);
+            const col = lastBoardCellRef.current % 3;
+            if (!board[row][col]) return lastBoardCellRef.current;
+        }
+        if (!board[1][1]) return 4;
+        for (let index = 0; index < 9; index++) {
+            if (!board[Math.floor(index / 3)][index % 3]) return index;
+        }
+        return 4;
+    };
+
+    const { pos, focus, setPosSilently, isFocused } = useCursorNav({
+        groups: [
+            { id: "hand", size: currentPlayerHand.length },
+            { id: "board", size: 9 },
+        ],
+        initial: null,
+        fallback: { group: "hand", index: 0 },
+        enabled: isGameActive && turn === "blue" && !winState && !isMenuOpen && !isCardSelectionOpen && !isCardGalleryOpen && !isRewardSelectionOpen,
+        resolveMove: (current, dir, { wrap }) => {
+            if (current.group === "hand") {
+                if ((dir === "up" || dir === "down") && currentPlayerHand.length > 0) {
+                    return { group: "hand", index: wrap(current.index, (dir === "down") ? 1 : -1, currentPlayerHand.length) };
+                }
+                return null;
+            }
+            const row = Math.floor(current.index / 3);
+            const col = current.index % 3;
+            const nextRow = (dir === "up") ? (row + 2) % 3 : (dir === "down") ? (row + 1) % 3 : row;
+            const nextCol = (dir === "left") ? (col + 2) % 3 : (dir === "right") ? (col + 1) % 3 : col;
+            return { group: "board", index: nextRow * 3 + nextCol };
+        },
+        onFocus: (current) => {
+            gameNav.setFocus(current.group === "hand" ? { player: "blue", index: current.index } : null);
+        },
+        onConfirm: (current) => {
+            if (current.group === "hand") {
+                const card = currentPlayerHand[current.index];
+                if (!card) return;
+                playSound("select", isSoundEnabled);
+                dispatch({ type: "SET_SELECTED_CARD_ID", payload: card.uniqueId });
+                lastHandIndexRef.current = current.index;
+                gameNav.setFocus(null);
+                setPosSilently({ group: "board", index: firstPlacementCell() });
+                return;
+            }
+            const row = Math.floor(current.index / 3);
+            const col = current.index % 3;
+            if (!board[row][col] && selectedCard && selectedCard.currentOwner === turn) {
+                lastBoardCellRef.current = current.index;
+                handlePlayerBoardSelection(row, col);
+            } else {
+                playSound("error", isSoundEnabled);
+            }
+        },
+        onCancel: () => {
+            if (pos?.group !== "board") return;
+            dispatch({ type: "SET_SELECTED_CARD_ID", payload: null });
+            playSound("back", isSoundEnabled);
+            const index = Math.min(lastHandIndexRef.current, Math.max(0, currentPlayerHand.length - 1));
+            setPosSilently({ group: "hand", index });
+            gameNav.setFocus({ player: "blue", index });
+        },
+    });
+
+    posRef.current = pos;
+
+    // Let mouse hover on blue hand cards move the shared cursor
+    useEffect(() => {
+        gameNav.actions.focusHand = (index) => focus({ group: "hand", index });
+        return () => {
+            gameNav.actions.focusHand = undefined;
+        };
+    }, [focus]);
+
+    // After a placement (or any deselect) the cursor returns to the hand
+    useEffect(() => {
+        if (selectedCardId || pos?.group !== "board") return;
+        if (currentPlayerHand.length === 0) {
+            setPosSilently(null);
+            gameNav.setFocus(null);
+            return;
+        }
+        const index = Math.min(lastHandIndexRef.current, currentPlayerHand.length - 1);
+        setPosSilently({ group: "hand", index });
+        gameNav.setFocus({ player: "blue", index });
+    }, [selectedCardId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Keyboard-started games begin with the cursor on the first hand card
+    useEffect(() => {
+        if (isGameActive) {
+            if (consumeKeyboardNavIntent()) {
+                setPosSilently({ group: "hand", index: 0 });
+                gameNav.setFocus({ player: "blue", index: 0 });
+            }
+        } else {
+            setPosSilently(null);
+            gameNav.setFocus(null);
+        }
+    }, [isGameActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
 
     useEffect(() => {
@@ -454,16 +565,31 @@ const Board: React.FC<BoardProps> = ({ className }) => {
                 setTimeout(() => {
                     playSound("select", isSoundEnabled);
 
+                    // The cursor follows the AI: first onto its chosen hand card
+                    const enemyHandIndex = currentEnemyHand.findIndex(card => card.uniqueId === uniqueId);
+                    gameNav.setFocus({ player: "red", index: Math.max(0, enemyHandIndex) });
+
                     dispatch({
                         type: "SET_SELECTED_CARD_ID",
                         payload: enemyCard.uniqueId,
                     })
 
                     setTimeout(() => {
-                        grabCardFromHand(enemyCard, "red");
-                        placeCard(enemyPosition.row, enemyPosition.col, enemyCard);
-                        playSound("place", isSoundEnabled);
-                        swapTurn();
+                        // ...then onto the target cell, before the card lands
+                        gameNav.setFocus(null);
+                        setAiBoardCell(enemyPosition.row * 3 + enemyPosition.col);
+
+                        setTimeout(() => {
+                            setAiBoardCell(null);
+                            grabCardFromHand(enemyCard, "red");
+                            placeCard(enemyPosition.row, enemyPosition.col, enemyCard);
+                            playSound("place", isSoundEnabled);
+                            swapTurn();
+                            // Hand the cursor back to the player's hand
+                            if (posRef.current?.group === "hand") {
+                                gameNav.setFocus({ player: "blue", index: posRef.current.index });
+                            }
+                        }, 500);
                     }, enemyDelay());
                 }, enemyDelay());
             }
@@ -505,6 +631,7 @@ const Board: React.FC<BoardProps> = ({ className }) => {
                             className={styles.cell}
                             data-position={[rowIndex, colIndex]}
                             data-selectable={!board[rowIndex][colIndex] && turn === "blue" && !!selectedCardId}
+                            data-focused={isFocused("board", rowIndex * 3 + colIndex) || aiBoardCell === rowIndex * 3 + colIndex}
                             data-element={(elements && String([rowIndex, colIndex]) in elements) ? elements[String([rowIndex, colIndex])] : null}
                             onMouseEnter={() => handleMouseEnter(rowIndex, colIndex)}
                             onClick={() => handlePlayerBoardSelection(rowIndex, colIndex)}

--- a/src/app/components/Board/Board.tsx
+++ b/src/app/components/Board/Board.tsx
@@ -560,41 +560,73 @@ const Board: React.FC<BoardProps> = ({ className }) => {
                 const { enemyCardId, enemyPosition, uniqueId } = enemyMove;
                 if (!enemyCardId) return;
 
-                const enemyDelay = () => Math.floor(Math.random() * 2000) + 1000;
                 const enemyCard = [...currentEnemyHand].find(card => card.uniqueId === uniqueId);
 
                 if (!enemyCard) return;
 
+                const targetIndex = Math.max(0, currentEnemyHand.findIndex(card => card.uniqueId === uniqueId));
+                const handSize = currentEnemyHand.length;
+
+                // The AI's cursor starts on its top card and walks down to its
+                // pick, sometimes lingering on a decoy as though changing its mind
+                const walk: number[] = [0];
+                const pushWalk = (from: number, to: number) => {
+                    const step = (to >= from) ? 1 : -1;
+                    for (let i = from + step; (step > 0) ? i <= to : i >= to; i += step) walk.push(i);
+                };
+
+                let decoyIndex: number | null = null;
+                if (handSize > 1 && Math.random() < 0.6) {
+                    const candidates = Array.from({ length: handSize }, (_, index) => index).filter(index => index !== targetIndex && index !== 0);
+                    if (candidates.length) decoyIndex = candidates[Math.floor(Math.random() * candidates.length)];
+                }
+
+                if (decoyIndex !== null) {
+                    pushWalk(0, decoyIndex);
+                    pushWalk(decoyIndex, targetIndex);
+                } else {
+                    pushWalk(0, targetIndex);
+                }
+
+                let delay = Math.floor(Math.random() * 800) + 700;
+                walk.forEach((index) => {
+                    setTimeout(() => {
+                        playSound("select", isSoundEnabled);
+                        gameNav.setFocus({ player: "red", index });
+                    }, delay);
+                    // a longer beat on the decoy card sells the hesitation
+                    delay += (index === decoyIndex)
+                        ? Math.floor(Math.random() * 400) + 550
+                        : Math.floor(Math.random() * 120) + 220;
+                });
+
+                delay += Math.floor(Math.random() * 500) + 400;
                 setTimeout(() => {
-                    playSound("select", isSoundEnabled);
-
-                    // The cursor follows the AI: first onto its chosen hand card
-                    const enemyHandIndex = currentEnemyHand.findIndex(card => card.uniqueId === uniqueId);
-                    gameNav.setFocus({ player: "red", index: Math.max(0, enemyHandIndex) });
-
                     dispatch({
                         type: "SET_SELECTED_CARD_ID",
                         payload: enemyCard.uniqueId,
                     })
+                }, delay);
 
-                    setTimeout(() => {
-                        // ...then onto the target cell, before the card lands
-                        gameNav.setFocus(null);
-                        setAiBoardCell(enemyPosition.row * 3 + enemyPosition.col);
+                delay += Math.floor(Math.random() * 900) + 700;
+                setTimeout(() => {
+                    // ...then onto the target cell, before the card lands
+                    gameNav.setFocus(null);
+                    setAiBoardCell(enemyPosition.row * 3 + enemyPosition.col);
+                }, delay);
 
-                        setTimeout(() => {
-                            setAiBoardCell(null);
-                            grabCardFromHand(enemyCard, "red");
-                            placeCard(enemyPosition.row, enemyPosition.col, enemyCard);
-                            playSound("place", isSoundEnabled);
-                            swapTurn();
-                            // Hand the cursor back to the player's hand
-                            if (posRef.current?.group === "hand") {
-                                gameNav.setFocus({ player: "blue", index: posRef.current.index });
-                            }
-                        }, 500);
-                    }, enemyDelay());
-                }, enemyDelay());
+                delay += 500;
+                setTimeout(() => {
+                    setAiBoardCell(null);
+                    grabCardFromHand(enemyCard, "red");
+                    placeCard(enemyPosition.row, enemyPosition.col, enemyCard);
+                    playSound("place", isSoundEnabled);
+                    swapTurn();
+                    // Hand the cursor back to the player's hand
+                    if (posRef.current?.group === "hand") {
+                        gameNav.setFocus({ player: "blue", index: posRef.current.index });
+                    }
+                }, delay);
             }
         }
     }, [turn]);

--- a/src/app/components/CardGallery/CardGallery.tsx
+++ b/src/app/components/CardGallery/CardGallery.tsx
@@ -8,9 +8,10 @@ import textToSprite from "../../utils/textToSprite";
 import SimpleDialog from "../SimpleDialog/SimpleDialog";
 import CardSelectionDialog from "../CardSelectionDialog/CardSelectionDialog";
 import CardValues from "../CardValues/CardValues";
+import playSound from "../../utils/sounds";
 
 const CardGallery = () => {
-    const { playerCards, currentPlayerCards, previewCardId, currentPages, lostCards, dispatch } = useGameContext();
+    const { playerCards, currentPlayerCards, previewCardId, currentPages, lostCards, isSoundEnabled, dispatch } = useGameContext();
 
     const previewCardData = cards.find(card => card.id === previewCardId);
     let previewCardLocation;
@@ -36,12 +37,6 @@ const CardGallery = () => {
         dispatch({ type: "SET_IS_CARD_GALLERY_OPEN", payload: false });
     }
 
-    window.addEventListener("keydown", (e) => {
-        if (e.key === "Escape" && currentPages.cardGallery > 0) {
-            handleDismissGallery();
-        }
-    });
-
     const titleType = currentPages.cardGallery < 6 ? "Monster" : currentPages.cardGallery < 8 ? "Boss" : currentPages.cardGallery < 10 ? "GF" : "Player";
     const currentPageTitle = `Level ${currentPages.cardGallery} ${titleType} Cards`;
 
@@ -54,7 +49,7 @@ const CardGallery = () => {
                 </div>
                 <div className="flex justify-between gap-1 my-1">
                     <div className="w-1/2 ml-4">
-                        <CardSelectionDialog showPreview={false} showMissingCards={true} modifier="card-gallery" pagination="cardGallery" />
+                        <CardSelectionDialog showPreview={false} showMissingCards={true} modifier="card-gallery" pagination="cardGallery" onCancel={() => { playSound("back", isSoundEnabled); handleDismissGallery(); }} />
                     </div>
                     <div className="w-1/2 mr-4 flex flex-col gap-1">
                         <SimpleDialog className={`${styles.cardDetails} flex justify-between`} metaTitle={null}>

--- a/src/app/components/CardSelectionDialog/CardSelectionDialog.module.scss
+++ b/src/app/components/CardSelectionDialog/CardSelectionDialog.module.scss
@@ -28,7 +28,7 @@
     }
 
     .cardListItem {
-        &:hover {
+        &[data-focused=true] {
             &:before {
                 content: "";
                 position: absolute;

--- a/src/app/components/CardSelectionDialog/CardSelectionDialog.tsx
+++ b/src/app/components/CardSelectionDialog/CardSelectionDialog.tsx
@@ -12,15 +12,20 @@ import DialogPagination from "../DialogPagination/DialogPagination";
 import textToSprite from "../../utils/textToSprite";
 import { generateCardFromId } from "../../utils/general";
 import SimpleDialog from "../SimpleDialog/SimpleDialog";
+import { useCursorNav, markKeyboardNavigation } from "../../hooks/useCursorNav";
+import { paginationNav } from "../../hooks/paginationNav";
 
 interface CardSelectionDialogProps {
     showPreview?: boolean;
     showMissingCards?: boolean;
     modifier?: string;
     pagination?: string;
+    onCancel?: () => void;
 }
 
-const CardSelectionDialog: React.FC<CardSelectionDialogProps> = ({ showPreview = true, showMissingCards = false, modifier, pagination = "cards" }) => {
+const ITEMS_PER_PAGE = 11;
+
+const CardSelectionDialog: React.FC<CardSelectionDialogProps> = ({ showPreview = true, showMissingCards = false, modifier, pagination = "cards", onCancel }) => {
     const { playerCards, currentPlayerCards, previewCardId, currentPlayerHand, enemyId, lostCards, score, isCardSelectionOpen, isCardGalleryOpen, isSoundEnabled, currentPages, slideDirection, rules, dispatch } = useGameContext();
 
     const hand: CardType[] = [...currentPlayerHand];
@@ -70,11 +75,9 @@ const CardSelectionDialog: React.FC<CardSelectionDialogProps> = ({ showPreview =
         dispatch({ type: "SET_CURRENT_PLAYER_CARDS", payload: cards });
     }
 
-    const handleCardHover = (id: number) => {
+    const setCardPreview = (id: number) => {
         const previewValue = !(Object.keys(playerCards).find(cardId => cardId === String(id))) ? null : id;
         dispatch({ type: "SET_PREVIEW_CARD_ID", payload: previewValue });
-
-        if (currentPlayerHand.length < 5) playSound("select", isSoundEnabled);
     };
 
     const handleConfirmation = () => {
@@ -92,11 +95,92 @@ const CardSelectionDialog: React.FC<CardSelectionDialogProps> = ({ showPreview =
         dispatch({ type: "SET_CURRENT_PLAYER_CARDS", payload: playerCards });
     }
 
-    const cardContent = (item: { id: number, location: string, player: string, additionalDesc: string }, quantity: number) => (
+    const isGalleryInstance = pagination === "cardGallery";
+    const currentPage = currentPages[pagination];
+    const pageItems = Object.entries(cards).slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+    const isItemUnowned = (index: number) => {
+        const entry = pageItems[index];
+        return !entry || !(Object.keys(playerCards).find(cardId => cardId === entry[0]));
+    };
+
+    const { pos, focus, isFocused } = useCursorNav({
+        groups: [{ id: "list", size: pageItems.length, isDisabled: isGalleryInstance ? isItemUnowned : undefined }],
+        initial: null,
+        fallback: { group: "list", index: 0 },
+        enabled: isGalleryInstance
+            ? isCardGalleryOpen
+            : (isCardSelectionOpen && !isCardGalleryOpen && currentPlayerHand.length < 5),
+        resolveMove: (current, dir, { wrap }) => {
+            if (dir === "left" || dir === "right") {
+                paginationNav.flip(pagination, (dir === "left") ? "prev" : "next");
+                return "handled";
+            }
+            const size = pageItems.length;
+            if (size === 0) return null;
+            const delta = (dir === "down") ? 1 : -1;
+            let index = current.index;
+            for (let step = 0; step < size; step++) {
+                index = wrap(index, delta, size);
+                if (!isGalleryInstance || !isItemUnowned(index)) return { group: "list", index };
+            }
+            return null;
+        },
+        resolvePageJump: (_, dir) => {
+            paginationNav.flip(pagination, (dir === "pageUp") ? "prev" : "next");
+            return "handled";
+        },
+        onFocus: (current) => {
+            const entry = pageItems[current.index];
+            if (entry) setCardPreview(Number(entry[0]));
+        },
+        onConfirm: (current) => {
+            if (isGalleryInstance) return;
+            const entry = pageItems[current.index];
+            if (!entry) return;
+            const [cardId, quantity] = entry;
+            if (currentPlayerHand.length === 4 && cards[Number(cardId)] > 0) {
+                // The 5th pick opens the confirmation dialog focused on Yes
+                markKeyboardNavigation();
+            }
+            handleCardSelection(Number(cardId), quantity);
+        },
+        onCancel: () => {
+            if (isGalleryInstance) {
+                onCancel?.();
+                return;
+            }
+            if (currentPlayerHand.length > 0) {
+                // FF8: cancel takes back the most recently picked card
+                const newHand = [...currentPlayerHand];
+                const removed = newHand.pop();
+                const newCards = { ...currentPlayerCards };
+                if (removed) newCards[removed.cardId] = (newCards[removed.cardId] ?? 0) + 1;
+                score[1] -= 1;
+                playSound("back", isSoundEnabled);
+                dispatch({ type: "SET_CURRENT_PLAYER_HAND", payload: newHand });
+                dispatch({ type: "SET_CURRENT_PLAYER_CARDS", payload: newCards });
+                return;
+            }
+            playSound("back", isSoundEnabled);
+            markKeyboardNavigation();
+            dispatch({ type: "SET_IS_CARD_SELECTION_OPEN", payload: false });
+            dispatch({ type: "SET_IS_MENU_OPEN", payload: true });
+        },
+    });
+
+    // Keep the preview in sync with the card under the cursor after a page flip
+    useEffect(() => {
+        if (!pos || pos.group !== "list") return;
+        const entry = pageItems[Math.min(pos.index, pageItems.length - 1)];
+        if (entry) setCardPreview(Number(entry[0]));
+    }, [currentPage]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const cardContent = (item: { id: number, location: string, player: string, additionalDesc: string }, quantity: number, pageIndex: number) => (
         <div
             key={item.id}
             onClick={() => handleCardSelection(item.id, quantity)}
-            onMouseEnter={() => handleCardHover(item.id)}
+            onMouseEnter={() => focus({ group: "list", index: pageIndex })}
+            data-focused={isFocused("list", pageIndex) && (isGalleryInstance || currentPlayerHand.length < 5)}
             className={`${styles.cardListItem} flex justify-between ${!(Object.keys(playerCards).find(cardId => cardId === String(item.id))) ? "opacity-0" : quantity ? "cursor-pointer" : "opacity-50"}`}
             data-slide-direction={(slideDirection && slideDirection[0] === pagination) ? slideDirection[1] : null}
             style={isCardGalleryOpen ? { zoom: 1.27 } : undefined}
@@ -162,8 +246,8 @@ const CardSelectionDialog: React.FC<CardSelectionDialogProps> = ({ showPreview =
                     </h4>
                     <h4 className={`${styles.meta} mr-3`} data-sprite="num.">Num.</h4>
                 </div>
-                <DialogPagination items={Object.entries(cards)} itemsPerPage={11} renderItem={([cardId, quantity]: [number, number]) =>
-                    cardContent({ id: Number(cardId), location: '', player: '', additionalDesc: '' }, quantity)} pagination={pagination} />
+                <DialogPagination items={Object.entries(cards)} itemsPerPage={ITEMS_PER_PAGE} renderItem={([cardId, quantity]: [number, number], globalIndex: unknown) =>
+                    cardContent({ id: Number(cardId), location: '', player: '', additionalDesc: '' }, quantity, Number(globalIndex) - (currentPage - 1) * ITEMS_PER_PAGE)} pagination={pagination} />
 
                 {currentPlayerHand.length === 5 && !isCardGalleryOpen && <ConfirmationDialog handleConfirmation={handleConfirmation} handleDenial={handleDenial} />}
                 {showPreview && previewCardId && <div key={previewCardId} className={`${styles.cardSelectionPreview} absolute`}>

--- a/src/app/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/app/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { createPortal } from "react-dom";
 import styles from './ConfirmationDialog.module.scss';
 import { useGameContext } from '../../context/GameContext';
-import playSound from "../../utils/sounds";
 import textToSprite from '../../utils/textToSprite';
+import { useCursorNav, markKeyboardNavigation } from "../../hooks/useCursorNav";
 
 interface MenuProps {
     handleConfirmation: () => void;
@@ -11,11 +11,30 @@ interface MenuProps {
 }
 
 const ConfirmationDialog: React.FC<MenuProps> = ({ handleConfirmation, handleDenial }) => {
-    const { isSoundEnabled } = useGameContext();
+    const { isCardGalleryOpen } = useGameContext();
 
-    const handleMouseEnter = () => {
-        playSound("select", isSoundEnabled);
-    }
+    const { focus, isFocused } = useCursorNav({
+        groups: [{ id: "choice", size: 2 }],
+        initial: null,
+        fallback: { group: "choice", index: 0 },
+        enabled: !isCardGalleryOpen,
+        resolveMove: (current, dir, { wrap }) => {
+            if (dir === "up" || dir === "down") {
+                return { group: "choice", index: wrap(current.index, (dir === "down") ? 1 : -1, 2) };
+            }
+            return null;
+        },
+        onFocus: () => { },
+        onConfirm: (current) => {
+            if (current.index === 0) {
+                markKeyboardNavigation();
+                handleConfirmation();
+            } else {
+                handleDenial();
+            }
+        },
+        onCancel: () => handleDenial(),
+    });
 
     const modalElement = document.getElementById("modal");
 
@@ -27,8 +46,8 @@ const ConfirmationDialog: React.FC<MenuProps> = ({ handleConfirmation, handleDen
                 <h4 className={styles.meta} data-sprite="choice">Choice</h4>
                 <h3 className="text-center">{textToSprite("Are you sure?")}</h3>
                 <div className="flex flex-col items-center">
-                    <button className="relative" onClick={handleConfirmation} onMouseEnter={handleMouseEnter}>{textToSprite("Yes")}</button>
-                    <button className="relative" onClick={handleDenial} onMouseEnter={handleMouseEnter}>{textToSprite("No")}</button>
+                    <button className="relative" data-focused={isFocused("choice", 0)} onClick={handleConfirmation} onMouseEnter={() => focus({ group: "choice", index: 0 })}>{textToSprite("Yes")}</button>
+                    <button className="relative" data-focused={isFocused("choice", 1)} onClick={handleDenial} onMouseEnter={() => focus({ group: "choice", index: 1 })}>{textToSprite("No")}</button>
                 </div>
             </div>
         </div>,

--- a/src/app/components/DialogPagination/DialogPagination.tsx
+++ b/src/app/components/DialogPagination/DialogPagination.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react"
 import styles from './DialogPagination.module.scss';
 import { useGameContext } from '../../context/GameContext';
+import { paginationNav } from "../../hooks/paginationNav";
 import playSound from "../../utils/sounds";
 
 interface DialogPaginationProps<T> {
@@ -50,6 +51,12 @@ const DialogPagination = <T,>({ items, itemsPerPage = 1, renderItem, pagination 
         allPages[pagination] = next;
         dispatch({ type: "SET_CURRENT_PAGES", payload: allPages })
     }
+
+    // Expose the page-flip handlers (slide animation + sound included) to keyboard navigation
+    useEffect(() => {
+        paginationNav.register(pagination, { prev: handlePreviousClick, next: handleNextClick });
+        return () => paginationNav.unregister(pagination);
+    });
 
     return (
         <div className={styles.paginationContainer}>

--- a/src/app/components/EnemySelection/EnemySelection.module.scss
+++ b/src/app/components/EnemySelection/EnemySelection.module.scss
@@ -17,4 +17,18 @@
     &>div {
         margin-top: -5px;
     }
+
+    &[data-focused=true]::after {
+        content: "";
+        position: absolute;
+        left: 24px;
+        top: 50%;
+        transform: translateY(-50%);
+        background-image: url("/assets/cursor.png");
+        background-size: cover;
+        width: 45px;
+        height: 28px;
+        z-index: 4;
+        image-rendering: pixelated;
+    }
 }

--- a/src/app/components/EnemySelection/EnemySelection.tsx
+++ b/src/app/components/EnemySelection/EnemySelection.tsx
@@ -8,7 +8,11 @@ import tradeRules from "../../../data/rules.json";
 import DialogPagination from "../DialogPagination/DialogPagination";
 import textToSprite from "../../utils/textToSprite";
 
-const EnemySelectionDialog = () => {
+interface EnemySelectionProps {
+    focused?: boolean;
+}
+
+const EnemySelectionDialog = ({ focused = false }: EnemySelectionProps) => {
     const { isMenuOpen, currentPages, slideDirection, lostCards, playerCards, dispatch } = useGameContext();
     const [lostCardMap, setLostCardMap] = useState<{ [id: string]: boolean }>({});
 
@@ -61,7 +65,7 @@ const EnemySelectionDialog = () => {
     };
 
     return (
-        <div className={`${styles.enemySelectionDialog} ${isMenuOpen ? "" : "hidden"} top-[80%]`}>
+        <div className={`${styles.enemySelectionDialog} ${isMenuOpen ? "" : "hidden"} top-[80%]`} data-focused={focused}>
             <h4 className={styles.meta} data-sprite="players">Players</h4>
             <DialogPagination items={filteredPlayers} itemsPerPage={1} renderItem={playerContent} pagination="players" />
         </div>

--- a/src/app/components/Hand/Hand.module.scss
+++ b/src/app/components/Hand/Hand.module.scss
@@ -29,31 +29,23 @@
 
         [data-player] {
             box-shadow: inset 0 0 0 1px #fff;
-
-            &:hover {
-                &::after {
-                    position: absolute;
-                    top: 16px;
-                }
-            }
-
-            &[data-player=blue] {
-                &:hover {
-                    &::after {
-                        content: "";
-                        position: absolute;
-                        left: -36px;
-                        background-image: url("/assets/cursor.png");
-                        background-size: cover;
-                        width: 45px;
-                        height: 28px;
-                        margin-top: 50px;
-                        z-index: 4;
-                        image-rendering: pixelated;
-                    }
-                }
-            }
         }
+    }
+
+    // The shared cursor, shown on whichever hand card is focused
+    // (blue via keyboard/hover, red while the AI picks its card)
+    >div[data-focused=true] [data-player]::after {
+        content: "";
+        position: absolute;
+        top: 16px;
+        left: -36px;
+        background-image: url("/assets/cursor.png");
+        background-size: cover;
+        width: 45px;
+        height: 28px;
+        margin-top: 50px;
+        z-index: 4;
+        image-rendering: pixelated;
     }
 }
 

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useSyncExternalStore } from 'react';
 import styles from './Hand.module.scss';
 import Card from '../Card/Card';
 import Indicator from '../Indicator/Indicator';
 import { useGameContext } from "../../context/GameContext";
 import { CardType, PlayerType } from "../../context/GameTypes";
 import playSound from "../../utils/sounds";
+import { gameNav } from "../../hooks/gameNav";
 
 interface HandProps {
     className?: string;
@@ -14,6 +15,7 @@ interface HandProps {
 const Hand: React.FC<HandProps> = ({ className, player }) => {
     const { currentPlayerHand, currentEnemyHand, turn, turnNumber, selectedCardId, score, isMenuOpen, isGameActive, isSoundEnabled, dispatch } = useGameContext();
     const cards = (player === "red") ? currentEnemyHand : currentPlayerHand;
+    const handFocus = useSyncExternalStore(gameNav.subscribe, gameNav.getFocus, () => null);
 
     const handleSelectCard = (card: CardType, player: PlayerType) => {
         playSound("select", isSoundEnabled);
@@ -25,9 +27,9 @@ const Hand: React.FC<HandProps> = ({ className, player }) => {
         });
     };
 
-    const handleMouseEnter = () => {
-        if (player === "blue" && turn === "blue") {
-            playSound("select", isSoundEnabled);
+    const handleMouseEnter = (index: number) => {
+        if (player === "blue" && turn === "blue" && isGameActive) {
+            gameNav.actions.focusHand?.(index);
         }
     }
 
@@ -37,7 +39,7 @@ const Hand: React.FC<HandProps> = ({ className, player }) => {
                 {turnNumber < 10 && <Indicator className={(player === turn && turn === player) ? "flex" : "hidden"} type="TURN_INDICATOR" />}
                 <div className={`${styles.hand} flex flex-col ${(isGameActive) ? "justify-end" : "justify-start"}`} data-player={player} data-selectable={player === turn && turn === "blue"}>
                     {cards.map((card, index) => (
-                        <div key={index} className="cell" onClick={() => handleSelectCard(card, player)} onMouseEnter={handleMouseEnter} data-selected={(card.uniqueId && selectedCardId === card.uniqueId)}>
+                        <div key={index} className="cell" onClick={() => handleSelectCard(card, player)} onMouseEnter={() => handleMouseEnter(index)} data-selected={(card.uniqueId && selectedCardId === card.uniqueId)} data-focused={handFocus?.player === player && handFocus.index === index}>
                             <Card id={card.cardId} player={card.currentOwner as PlayerType} />
                         </div>
                     ))}

--- a/src/app/components/LocationSelection/LocationSelection.module.scss
+++ b/src/app/components/LocationSelection/LocationSelection.module.scss
@@ -18,4 +18,18 @@
     &>div {
         margin-top: -5px;
     }
+
+    &[data-focused=true]::after {
+        content: "";
+        position: absolute;
+        left: 24px;
+        top: 50%;
+        transform: translateY(-50%);
+        background-image: url("/assets/cursor.png");
+        background-size: cover;
+        width: 45px;
+        height: 28px;
+        z-index: 4;
+        image-rendering: pixelated;
+    }
 }

--- a/src/app/components/LocationSelection/LocationSelection.tsx
+++ b/src/app/components/LocationSelection/LocationSelection.tsx
@@ -5,7 +5,11 @@ import locations from "../../../data/locations.json";
 import DialogPagination from "../DialogPagination/DialogPagination";
 import textToSprite from "../../utils/textToSprite";
 
-const LocationSelectionDialog = () => {
+interface LocationSelectionProps {
+    focused?: boolean;
+}
+
+const LocationSelectionDialog = ({ focused = false }: LocationSelectionProps) => {
     const { isMenuOpen, currentPages, slideDirection, dispatch } = useGameContext();
 
     useEffect(() => {
@@ -28,7 +32,7 @@ const LocationSelectionDialog = () => {
     };
 
     return (
-        <div className={`${styles.locationSelectionDialog} ${isMenuOpen ? "" : "hidden"} top-[80%]`}>
+        <div className={`${styles.locationSelectionDialog} ${isMenuOpen ? "" : "hidden"} top-[80%]`} data-focused={focused}>
             <h4 className={styles.meta} data-sprite="location">Location</h4>
             <DialogPagination items={locations} itemsPerPage={1} renderItem={locationContent} pagination="locations" />
         </div>

--- a/src/app/components/MenuDialog/MenuDialog.tsx
+++ b/src/app/components/MenuDialog/MenuDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import styles from './MenuDialog.module.scss';
 import { useGameContext } from "../../context/GameContext";
 import playSound from "../../utils/sounds";
@@ -5,9 +6,24 @@ import LocationSelectionDialog from '../LocationSelection/LocationSelection';
 import EnemySelectionDialog from '../EnemySelection/EnemySelection';
 import textToSprite from '../../utils/textToSprite';
 import rulesList from "../../../data/rules.json";
+import { useCursorNav, markKeyboardNavigation } from "../../hooks/useCursorNav";
+import type { CursorPos } from "../../hooks/useCursorNav";
+import { paginationNav } from "../../hooks/paginationNav";
+import { optionsNav } from "../../hooks/optionsNav";
+
+const OPTIONS_SIZE = 4;
+
+// Vertical cursor chain: Play, Quit, location row, enemy row, options panel
+const CHAIN: CursorPos[] = [
+    { group: "buttons", index: 0 },
+    { group: "buttons", index: 1 },
+    { group: "location", index: 0 },
+    { group: "enemy", index: 0 },
+    { group: "options", index: 0 },
+];
 
 const MenuDialog = () => {
-    const { isMenuOpen, isSoundEnabled, rules, tradeRule, dispatch } = useGameContext();
+    const { isMenuOpen, isCardGalleryOpen, isSoundEnabled, rules, tradeRule, dispatch } = useGameContext();
 
     const handlePlayClick = () => {
         dispatch({ type: "SET_IS_MENU_OPEN", payload: false });
@@ -19,9 +35,87 @@ const MenuDialog = () => {
         playSound("error", isSoundEnabled);
     }
 
-    const handleMouseEnter = () => {
-        playSound("select", isSoundEnabled);
-    }
+    const isOptionEnabled = (index: number) => index === 0 || !!optionsNav.actions.isOpen?.();
+
+    const chainIndexOf = (pos: CursorPos) => {
+        if (pos.group === "buttons") return pos.index;
+        if (pos.group === "location") return 2;
+        if (pos.group === "enemy") return 3;
+        return 4;
+    };
+
+    const { focus, isFocused } = useCursorNav({
+        groups: [
+            { id: "buttons", size: 2 },
+            { id: "location", size: 1 },
+            { id: "enemy", size: 1 },
+            { id: "options", size: OPTIONS_SIZE, isDisabled: (index) => !isOptionEnabled(index) },
+        ],
+        initial: null,
+        fallback: { group: "buttons", index: 0 },
+        enabled: isMenuOpen && !isCardGalleryOpen,
+        resolveMove: (current, dir) => {
+            if (dir === "left" || dir === "right") {
+                if (current.group === "location") {
+                    paginationNav.flip("locations", (dir === "left") ? "prev" : "next");
+                    return "handled";
+                }
+                if (current.group === "enemy") {
+                    paginationNav.flip("players", (dir === "left") ? "prev" : "next");
+                    return "handled";
+                }
+                if (current.group === "options") {
+                    for (let step = 1; step < OPTIONS_SIZE; step++) {
+                        const index = (current.index + ((dir === "right") ? step : -step) + OPTIONS_SIZE * 4) % OPTIONS_SIZE;
+                        if (isOptionEnabled(index)) return { group: "options", index };
+                    }
+                    return null;
+                }
+                return null;
+            }
+            const delta = (dir === "down") ? 1 : -1;
+            return CHAIN[(chainIndexOf(current) + delta + CHAIN.length) % CHAIN.length];
+        },
+        onFocus: (current) => {
+            optionsNav.setFocus(current.group === "options" ? current.index : null);
+        },
+        onConfirm: (current) => {
+            if (current.group === "buttons") {
+                if (current.index === 0) {
+                    markKeyboardNavigation();
+                    handlePlayClick();
+                } else {
+                    handleQuitClick();
+                }
+                return;
+            }
+            if (current.group === "location") {
+                paginationNav.flip("locations", "next");
+                return;
+            }
+            if (current.group === "enemy") {
+                paginationNav.flip("players", "next");
+                return;
+            }
+            if (!isOptionEnabled(current.index)) return;
+            if (current.index === 0) optionsNav.actions.toggleOptions?.();
+            else if (current.index === 1) optionsNav.actions.toggleCRT?.();
+            else if (current.index === 2) {
+                markKeyboardNavigation();
+                optionsNav.actions.toggleGallery?.();
+            }
+            else optionsNav.actions.toggleSound?.();
+        },
+    });
+
+    // Let mouse hover on the options panel move the menu cursor
+    useEffect(() => {
+        optionsNav.actions.focusOption = (index) => focus({ group: "options", index });
+        return () => {
+            optionsNav.actions.focusOption = undefined;
+            optionsNav.setFocus(null);
+        };
+    }, [focus]);
 
     return (
         <>
@@ -35,12 +129,12 @@ const MenuDialog = () => {
                 </ul>
                 <p>{textToSprite(`• Trade Rule: ${(tradeRule) ? rulesList.tradeRules[tradeRule as keyof typeof rulesList.tradeRules] : "None"}`)}</p>
                 <div className="flex flex-col items-center">
-                    <button className="relative" onClick={handlePlayClick} onMouseEnter={handleMouseEnter}>{textToSprite("Play")}</button>
-                    <button className="relative" onClick={handleQuitClick} onMouseEnter={handleMouseEnter}>{textToSprite("Quit")}</button>
+                    <button className="relative" data-focused={isFocused("buttons", 0)} onClick={handlePlayClick} onMouseEnter={() => focus({ group: "buttons", index: 0 })}>{textToSprite("Play")}</button>
+                    <button className="relative" data-focused={isFocused("buttons", 1)} onClick={handleQuitClick} onMouseEnter={() => focus({ group: "buttons", index: 1 })}>{textToSprite("Quit")}</button>
                 </div>
             </div>
-            <LocationSelectionDialog/>
-            <EnemySelectionDialog />
+            <LocationSelectionDialog focused={isFocused("location", 0)} />
+            <EnemySelectionDialog focused={isFocused("enemy", 0)} />
         </>
     );
 };

--- a/src/app/components/RewardSelectionDialog/RewardSelectionDialog.module.scss
+++ b/src/app/components/RewardSelectionDialog/RewardSelectionDialog.module.scss
@@ -17,14 +17,15 @@
     .cell {
         width: 128px;
         height: 163px;
-        position: relative;
 
+        // Anchored to the pseudo-element's static flow position (no top/left)
+        // so the cell needs no positioning of its own - the reward animations
+        // rely on the fixed container being the containing block
         &[data-focused=true]::after {
             content: "";
             position: absolute;
-            left: -22px;
-            top: 50%;
-            margin-top: -14px;
+            margin-left: -22px;
+            margin-top: -95px;
             background-image: url("/assets/cursor.png");
             background-size: cover;
             width: 45px;

--- a/src/app/components/RewardSelectionDialog/RewardSelectionDialog.module.scss
+++ b/src/app/components/RewardSelectionDialog/RewardSelectionDialog.module.scss
@@ -17,6 +17,22 @@
     .cell {
         width: 128px;
         height: 163px;
+        position: relative;
+
+        &[data-focused=true]::after {
+            content: "";
+            position: absolute;
+            left: -22px;
+            top: 50%;
+            margin-top: -14px;
+            background-image: url("/assets/cursor.png");
+            background-size: cover;
+            width: 45px;
+            height: 28px;
+            z-index: 5;
+            image-rendering: pixelated;
+            pointer-events: none;
+        }
     }
 
     [data-selected][data-confirmed] {

--- a/src/app/components/RewardSelectionDialog/RewardSelectionDialog.tsx
+++ b/src/app/components/RewardSelectionDialog/RewardSelectionDialog.tsx
@@ -7,6 +7,7 @@ import cards from '../../../data/cards.json';
 import ConfirmationDialog from "../ConfirmationDialog/ConfirmationDialog";
 import playSound, { stopLoadedSound } from "../../utils/sounds";
 import textToSprite from "../../utils/textToSprite";
+import { useCursorNav, markKeyboardNavigation } from "../../hooks/useCursorNav";
 
 interface RewardSelectionDialogProps {
     victorySound: HTMLAudioElement;
@@ -14,7 +15,7 @@ interface RewardSelectionDialogProps {
 }
 
 const RewardSelectionDialog: React.FC<RewardSelectionDialogProps> = ({ victorySound, bgm }) => {
-    const { playerCards, playerHand, enemyId, enemyHand, lostCards, winState, score, tradeRule, isSoundEnabled, board, dispatch } = useGameContext();
+    const { playerCards, playerHand, enemyId, enemyHand, lostCards, winState, score, tradeRule, isSoundEnabled, isCardGalleryOpen, board, dispatch } = useGameContext();
 
     type RewardType = { id: number; uniqueId: string | null | undefined, level: number, player: PlayerType, position: number }
 
@@ -120,17 +121,45 @@ const RewardSelectionDialog: React.FC<RewardSelectionDialogProps> = ({ victorySo
 
     const [hoveredReward, setHoveredReward] = useState<RewardType | undefined>(undefined);
 
-    const handleMouseEnter = (id: number, position: number) => {
-        if (winState === "blue" && !isSelectionConfirmed) playSound("select", isSoundEnabled);
+    const setRewardPreview = (id: number, position: number) => {
         const cardData = cards.find(card => card.id === id);
         if (!cardData) return;
 
         setHoveredReward({ id, uniqueId: null, level: cardData.level, player: (winState === "red") ? "blue" : "red", position });
     }
 
-    const handleMouseLeave = () => {
-        setHoveredReward(undefined);
-    }
+    const { focus, isFocused } = useCursorNav({
+        groups: [{ id: "rewards", size: playerRewardSelection.length }],
+        initial: null,
+        fallback: { group: "rewards", index: 0 },
+        enabled: isManualSelect && !isSelectionConfirmed && selectedRewards.won.length < winAmount && !isCardGalleryOpen,
+        resolveMove: (current, dir, { wrap }) => {
+            if ((dir === "left" || dir === "right") && playerRewardSelection.length > 0) {
+                return { group: "rewards", index: wrap(current.index, (dir === "right") ? 1 : -1, playerRewardSelection.length) };
+            }
+            return null;
+        },
+        onFocus: (current) => {
+            const card = playerRewardSelection[current.index];
+            if (card) setRewardPreview(card.id, current.index);
+        },
+        onConfirm: (current) => {
+            const card = playerRewardSelection[current.index];
+            if (!card) return;
+            if (card.player === winState) {
+                playSound("error", isSoundEnabled);
+                return;
+            }
+            if (selectedRewards.won.length === winAmount - 1) {
+                // The final pick opens the confirmation dialog focused on Yes
+                markKeyboardNavigation();
+            }
+            handleSelectReward(card, card.position);
+        },
+        onCancel: () => {
+            if (selectedRewards.won.length > 0) handleDenial();
+        },
+    });
 
 
     const autoSelectRewards = (method: "best" | "sequential") => {
@@ -301,8 +330,8 @@ const RewardSelectionDialog: React.FC<RewardSelectionDialogProps> = ({ victorySo
 
             <div className="flex justify-center mb-7">
                 {playerRewardSelection.map((card, index) => (
-                    <div className={styles.cell} key={index} onClick={() => handleSelectReward(card, card.position)}>
-                        <Card id={card.id} player={card.player} onMouseEnter={() => handleMouseEnter(card.id, index)} onMouseLeave={handleMouseLeave} data-selected={selectedRewards.won.some((reward) => reward.id === card.id && reward.position === card.position)} data-confirmed={isSelectionConfirmed && confirmedCards.some((reward) => reward.id === card.id && reward.position === card.position)} data-index={index} />
+                    <div className={styles.cell} key={index} data-focused={isFocused("rewards", index) && !isSelectionConfirmed && selectedRewards.won.length < winAmount} onClick={() => handleSelectReward(card, card.position)}>
+                        <Card id={card.id} player={card.player} onMouseEnter={() => { if (winState === "blue" && !isSelectionConfirmed) focus({ group: "rewards", index }); }} data-selected={selectedRewards.won.some((reward) => reward.id === card.id && reward.position === card.position)} data-confirmed={isSelectionConfirmed && confirmedCards.some((reward) => reward.id === card.id && reward.position === card.position)} data-index={index} />
                     </div>
                 ))}
             </div>

--- a/src/app/components/SimpleDialog/SimpleDialog.module.scss
+++ b/src/app/components/SimpleDialog/SimpleDialog.module.scss
@@ -30,8 +30,13 @@
             }
         }
 
-        &:hover {
+        &:hover,
+        &:has([data-focused="true"]) {
             opacity: 1;
+        }
+
+        [data-focused="true"] {
+            background-color: rgba(0, 0, 0, 0.25);
         }
 
         img {

--- a/src/app/hooks/gameNav.ts
+++ b/src/app/hooks/gameNav.ts
@@ -1,0 +1,32 @@
+// Bridge between the Board-owned gameplay cursor and the Hand components,
+// including the AI-driven cursor on the red hand.
+
+export type HandFocus = { player: "blue" | "red"; index: number } | null;
+
+let currentFocus: HandFocus = null;
+const listeners = new Set<() => void>();
+
+export const gameNav = {
+    actions: {} as {
+        /** Registered by the Board so hovering a blue hand card moves the shared cursor */
+        focusHand?: (index: number) => void;
+    },
+
+    getFocus(): HandFocus {
+        return currentFocus;
+    },
+
+    setFocus(focus: HandFocus) {
+        if (focus === currentFocus) return;
+        if (focus && currentFocus && focus.player === currentFocus.player && focus.index === currentFocus.index) return;
+        currentFocus = focus;
+        listeners.forEach((listener) => listener());
+    },
+
+    subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => {
+            listeners.delete(listener);
+        };
+    },
+};

--- a/src/app/hooks/optionsNav.ts
+++ b/src/app/hooks/optionsNav.ts
@@ -1,0 +1,33 @@
+// Bridge between the menu cursor and the always-mounted options panel.
+
+let focusedIndex: number | null = null;
+const listeners = new Set<() => void>();
+
+export const optionsNav = {
+    actions: {} as {
+        toggleOptions?: () => void;
+        toggleCRT?: () => void;
+        toggleGallery?: () => void;
+        toggleSound?: () => void;
+        isOpen?: () => boolean;
+        /** Registered by the MenuDialog so hovering an option moves the menu cursor */
+        focusOption?: (index: number) => void;
+    },
+
+    getFocus(): number | null {
+        return focusedIndex;
+    },
+
+    setFocus(index: number | null) {
+        if (index === focusedIndex) return;
+        focusedIndex = index;
+        listeners.forEach((listener) => listener());
+    },
+
+    subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => {
+            listeners.delete(listener);
+        };
+    },
+};

--- a/src/app/hooks/paginationNav.ts
+++ b/src/app/hooks/paginationNav.ts
@@ -1,0 +1,23 @@
+// Registry bridging keyboard page-flips to the existing DialogPagination
+// handlers (which own the slide animation, wrap-around and "place" sound).
+
+type PaginationHandlers = { prev: () => void; next: () => void };
+
+const registry = new Map<string, PaginationHandlers>();
+
+export const paginationNav = {
+    register(key: string, handlers: PaginationHandlers) {
+        registry.set(key, handlers);
+    },
+
+    unregister(key: string) {
+        registry.delete(key);
+    },
+
+    flip(key: string, direction: "prev" | "next") {
+        const handlers = registry.get(key);
+        if (!handlers) return false;
+        handlers[direction]();
+        return true;
+    },
+};

--- a/src/app/hooks/useCursorNav.ts
+++ b/src/app/hooks/useCursorNav.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import playSound from "../utils/sounds";
+import { useGameContext } from "../context/GameContext";
+
+export type NavDirection = "up" | "down" | "left" | "right";
+export type NavPageJump = "pageUp" | "pageDown";
+type NavAction = NavDirection | NavPageJump | "confirm" | "cancel";
+
+export interface CursorPos {
+    group: string;
+    index: number;
+}
+
+export interface NavGroup {
+    id: string;
+    size: number;
+    isDisabled?: (index: number) => boolean;
+}
+
+export interface CursorNavOptions {
+    groups: NavGroup[];
+    initial: CursorPos | null;
+    /** Where the cursor appears when a movement key is pressed while no cursor is shown */
+    fallback?: CursorPos;
+    enabled: boolean;
+    /** Return "handled" when the movement performed its own side effect (e.g. a page flip) */
+    resolveMove: (pos: CursorPos, dir: NavDirection, helpers: { wrap: (index: number, delta: 1 | -1, size: number) => number }) => CursorPos | "handled" | null;
+    resolvePageJump?: (pos: CursorPos, dir: NavPageJump) => CursorPos | "handled" | null;
+    onFocus: (pos: CursorPos) => void;
+    onConfirm: (pos: CursorPos) => void;
+    onCancel?: () => void;
+}
+
+const KEY_MAP: Record<string, NavAction> = {
+    ArrowUp: "up", Numpad8: "up",
+    ArrowDown: "down", Numpad2: "down",
+    ArrowLeft: "left", Numpad4: "left",
+    ArrowRight: "right", Numpad6: "right",
+    Enter: "confirm", NumpadEnter: "confirm",
+    Space: "cancel", Numpad0: "cancel", Insert: "cancel", Escape: "cancel",
+    PageUp: "pageUp", Numpad9: "pageUp",
+    PageDown: "pageDown", Numpad3: "pageDown",
+};
+
+const wrap = (index: number, delta: 1 | -1, size: number) => (index + delta + size) % size;
+
+// When navigation is triggered by keyboard, the destination surface starts
+// with its first item focused; mouse navigation starts with no cursor.
+let keyboardNavIntent = false;
+
+export const markKeyboardNavigation = () => {
+    keyboardNavIntent = true;
+};
+
+export const consumeKeyboardNavIntent = () => {
+    const intent = keyboardNavIntent;
+    keyboardNavIntent = false;
+    return intent;
+};
+
+const isEditableTarget = (target: EventTarget | null) => {
+    if (!(target instanceof HTMLElement)) return false;
+    if (target.isContentEditable || target.tagName === "TEXTAREA") return true;
+    return target instanceof HTMLInputElement && target.type !== "range";
+};
+
+export function useCursorNav(options: CursorNavOptions) {
+    const { isSoundEnabled } = useGameContext();
+
+    const [pos, setPos] = useState<CursorPos | null>(() => {
+        if (consumeKeyboardNavIntent()) {
+            return options.fallback ?? options.initial;
+        }
+        return options.initial;
+    });
+
+    const stateRef = useRef({ options, pos, isSoundEnabled });
+    stateRef.current = { options, pos, isSoundEnabled };
+
+    const initialFocusSentRef = useRef(false);
+
+    const moveTo = useCallback((next: CursorPos, silent: boolean) => {
+        const { options: opts, pos: current, isSoundEnabled: sound } = stateRef.current;
+        const group = opts.groups.find(g => g.id === next.group);
+        if (!group || next.index < 0 || next.index >= group.size) return;
+        if (group.isDisabled?.(next.index)) return;
+        if (current && current.group === next.group && current.index === next.index) return;
+
+        setPos(next);
+        if (!silent) playSound("select", sound);
+        opts.onFocus(next);
+    }, []);
+
+    const focus = useCallback((next: CursorPos) => moveTo(next, false), [moveTo]);
+    const setPosSilently = useCallback((next: CursorPos | null) => {
+        setPos(next);
+    }, []);
+
+    // Initial focus renders the focused option's preview without the cursor sound
+    useEffect(() => {
+        if (initialFocusSentRef.current) return;
+        initialFocusSentRef.current = true;
+        if (stateRef.current.pos) stateRef.current.options.onFocus(stateRef.current.pos);
+    }, []);
+
+    // Clamp when a group shrinks underneath the cursor
+    useEffect(() => {
+        if (!pos) return;
+        const group = options.groups.find(g => g.id === pos.group);
+        if (group && group.size > 0 && pos.index >= group.size) {
+            setPosSilently({ group: pos.group, index: group.size - 1 });
+        }
+    });
+
+    useEffect(() => {
+        if (!options.enabled) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const { options: opts, pos: current } = stateRef.current;
+
+            if (isEditableTarget(e.target)) return;
+
+            const action = KEY_MAP[e.code];
+            if (!action) return;
+            if (e.metaKey || e.altKey || e.ctrlKey) return;
+
+            e.preventDefault();
+            if (e.repeat && (action === "confirm" || action === "cancel")) return;
+
+            if (action === "confirm") {
+                if (current) opts.onConfirm(current);
+                else if (opts.fallback) moveTo(opts.fallback, false);
+                return;
+            }
+
+            if (action === "cancel") {
+                opts.onCancel?.();
+                return;
+            }
+
+            if (!current) {
+                if (opts.fallback) moveTo(opts.fallback, false);
+                return;
+            }
+
+            const next = (action === "pageUp" || action === "pageDown")
+                ? opts.resolvePageJump?.(current, action) ?? null
+                : opts.resolveMove(current, action, { wrap });
+
+            if (next === "handled" || !next) return;
+            moveTo(next, false);
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => {
+            window.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [options.enabled, moveTo]);
+
+    const isFocused = useCallback((group: string, index: number) =>
+        pos?.group === group && pos.index === index, [pos]);
+
+    return { pos, focus, setPosSilently, isFocused };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useSyncExternalStore } from "react";
 import Board from "./components/Board/Board";
 import Hand from "./components/Hand/Hand";
 import MenuDialog from "./components/MenuDialog/MenuDialog";
@@ -13,6 +13,7 @@ import CardGallery from "./components/CardGallery/CardGallery";
 import Image from "next/image";
 import SimpleDialog from "./components/SimpleDialog/SimpleDialog";
 import textToSprite from "./utils/textToSprite";
+import { optionsNav } from "./hooks/optionsNav";
 
 function GameContent() {
   const { isMenuOpen, isCardSelectionOpen, isCardGalleryOpen, isRewardSelectionOpen, winState, isSoundEnabled, isGameActive, currentPages, isCRTEffectActive, dispatch } = useGameContext();
@@ -96,6 +97,24 @@ function GameContent() {
     }
   }, [isCRTEffectActive]);
 
+  // Expose the options panel to the menu's keyboard cursor
+  const optionsFocus = useSyncExternalStore(optionsNav.subscribe, optionsNav.getFocus, () => null);
+
+  useEffect(() => {
+    optionsNav.actions.toggleOptions = handleToggleOptions;
+    optionsNav.actions.toggleCRT = handleToggleScanlines;
+    optionsNav.actions.toggleGallery = handleToggleCardGallery;
+    optionsNav.actions.toggleSound = handleSoundToggle;
+    optionsNav.actions.isOpen = () => isOptionsOpen;
+    return () => {
+      optionsNav.actions.toggleOptions = undefined;
+      optionsNav.actions.toggleCRT = undefined;
+      optionsNav.actions.toggleGallery = undefined;
+      optionsNav.actions.toggleSound = undefined;
+      optionsNav.actions.isOpen = undefined;
+    };
+  });
+
   return (
     <>
       <div id="app" className="max-w-4xl w-full h-full m-auto relative">
@@ -116,10 +135,10 @@ function GameContent() {
       <div className="absolute right-[1.5rem] bottom-[1.5rem] text-3xl z-50 flex items-center">
         <SimpleDialog metaTitle={null} dialog="options" data-expanded={isOptionsOpen}>
           <div className="flex items-center h-full">
-            <Image src="/assets/menu-expand.png?v=1" onClick={handleToggleOptions} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" />
-            <Image src="/assets/screenicon.png" onClick={handleToggleScanlines} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" data-selected={isCardGalleryOpen} />
-            <Image src="/assets/cardicon.png" onClick={handleToggleCardGallery} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" data-selected={isCardGalleryOpen} />
-            <div onClick={handleSoundToggle} className="flex items-center m-0">
+            <Image src="/assets/menu-expand.png?v=1" onClick={handleToggleOptions} onMouseEnter={() => optionsNav.actions.focusOption?.(0)} data-focused={optionsFocus === 0} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" />
+            <Image src="/assets/screenicon.png" onClick={handleToggleScanlines} onMouseEnter={() => optionsNav.actions.focusOption?.(1)} data-focused={optionsFocus === 1} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" data-selected={isCardGalleryOpen} />
+            <Image src="/assets/cardicon.png" onClick={handleToggleCardGallery} onMouseEnter={() => optionsNav.actions.focusOption?.(2)} data-focused={optionsFocus === 2} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" data-selected={isCardGalleryOpen} />
+            <div onClick={handleSoundToggle} onMouseEnter={() => optionsNav.actions.focusOption?.(3)} data-focused={optionsFocus === 3} className="flex items-center m-0">
               <span className="ml-3 mr-3">{textToSprite("Sound")}</span>
               <div className="flex items-center">
                 <span className={`${(!isSoundEnabled) ? "opacity-50" : ""} mr-3`}>{textToSprite("ON")}</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,7 +138,7 @@ function GameContent() {
             <Image src="/assets/menu-expand.png?v=1" onClick={handleToggleOptions} onMouseEnter={() => optionsNav.actions.focusOption?.(0)} data-focused={optionsFocus === 0} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" />
             <Image src="/assets/screenicon.png" onClick={handleToggleScanlines} onMouseEnter={() => optionsNav.actions.focusOption?.(1)} data-focused={optionsFocus === 1} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" data-selected={isCardGalleryOpen} />
             <Image src="/assets/cardicon.png" onClick={handleToggleCardGallery} onMouseEnter={() => optionsNav.actions.focusOption?.(2)} data-focused={optionsFocus === 2} className="my-0 mx-1 h-full" alt="Card Icon" width="27" height="27" data-selected={isCardGalleryOpen} />
-            <div onClick={handleSoundToggle} onMouseEnter={() => optionsNav.actions.focusOption?.(3)} data-focused={optionsFocus === 3} className="flex items-center m-0">
+            <div onClick={handleSoundToggle} onMouseEnter={() => optionsNav.actions.focusOption?.(3)} data-focused={optionsFocus === 3} className="flex items-center m-0 h-full">
               <span className="ml-3 mr-3">{textToSprite("Sound")}</span>
               <div className="flex items-center">
                 <span className={`${(!isSoundEnabled) ? "opacity-50" : ""} mr-3`}>{textToSprite("ON")}</span>

--- a/src/app/styles/dialog.module.scss
+++ b/src/app/styles/dialog.module.scss
@@ -14,7 +14,7 @@
         text-align: center;
         text-shadow: 2px 2px 0 #212121;
 
-        &:hover {
+        &[data-focused=true] {
             &::after {
                 content: "";
                 position: absolute;


### PR DESCRIPTION
Ports the cursor system from ff7-menu-port: useCursorNav hook, unified mouse/keyboard cursor, no cursor on load, keyboard-intent across screen transitions.

- Menu: Play/Quit + location/players rows (Left/Right flips pages with the existing slide animation) + options panel in one cursor chain
- Card selection: list navigation and paging, Enter picks; Cancel takes back the last pick, then exits to the menu
- Gameplay: Enter selects a hand card and dives onto the board, arrows wrap the 3x3 grid, Enter places, Cancel returns to hand
- The AI's cursor visibly walks its hand from the top card, sometimes lingering on a decoy before settling on its pick, then hovers the target cell — player input stays inert during its turn
- Rewards and card gallery navigable; fixes the gallery's leaky per-render Escape listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)