### PR TITLE
Disable mobile zoom and fix scale glitch while pinching

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,7 @@ body {
   overflow: hidden;
   display: flex;
   height: 100vh;
+  touch-action: manipulation; /* no double-tap zoom; the app scales itself */
 }
 
 body.crt-effect::after {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,13 @@
   }
 }
 
+/* Clamp the document so layout overflow (a WebKit zoom artifact) can never
+   grow the scrollable area and trigger mobile Safari's shrink-to-fit */
+html {
+  overflow: hidden;
+  height: 100%;
+}
+
 body {
   color: var(--foreground);
   background: var(--background);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,7 +24,14 @@ body {
   overflow: hidden;
   display: flex;
   height: 100vh;
-  touch-action: manipulation; /* no double-tap zoom; the app scales itself */
+}
+
+/* No double-tap or pinch zoom; the app scales itself. Safari only honours
+   touch-action on the element actually touched, so apply it everywhere */
+html,
+body,
+body * {
+  touch-action: manipulation;
 }
 
 body.crt-effect::after {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no"></meta>
         <link rel="icon" type="image/x-icon" href="/assets/cardicon.gif"></link>
       </head>
       <body

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1"></meta>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"></meta>
         <link rel="icon" type="image/x-icon" href="/assets/cardicon.gif"></link>
       </head>
       <body

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,11 +54,15 @@ function GameContent() {
 
       // iOS ignores user-scalable=no, so block pinch zoom; the app scales itself anyway
       const preventGesture = (event: Event) => event.preventDefault();
+      const preventPinch = (event: TouchEvent) => {
+        if (event.touches.length > 1) event.preventDefault();
+      };
 
       window.addEventListener('load', scaleApp);
       window.addEventListener('resize', scaleApp);
       document.addEventListener('gesturestart', preventGesture);
       document.addEventListener('gesturechange', preventGesture);
+      document.addEventListener('touchmove', preventPinch, { passive: false });
       scaleApp();
 
       return () => {
@@ -66,6 +70,7 @@ function GameContent() {
         window.removeEventListener('resize', scaleApp);
         document.removeEventListener('gesturestart', preventGesture);
         document.removeEventListener('gesturechange', preventGesture);
+        document.removeEventListener('touchmove', preventPinch);
       };
     }
   }, []);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,17 +43,30 @@ function GameContent() {
         const originalWidth = 950;
         const originalHeight = 750;
 
-        const windowWidth = window.innerWidth;
-        const windowHeight = window.innerHeight;
+        // The layout viewport stays stable while pinch-zooming, unlike innerWidth/innerHeight
+        const windowWidth = document.documentElement.clientWidth;
+        const windowHeight = document.documentElement.clientHeight;
 
         const scale = Math.min(windowWidth / originalWidth, windowHeight / originalHeight);
         app.style.zoom = String(scale);
         modal.style.zoom = String(scale);
       }
 
+      // iOS ignores user-scalable=no, so block pinch zoom; the app scales itself anyway
+      const preventGesture = (event: Event) => event.preventDefault();
+
       window.addEventListener('load', scaleApp);
       window.addEventListener('resize', scaleApp);
+      document.addEventListener('gesturestart', preventGesture);
+      document.addEventListener('gesturechange', preventGesture);
       scaleApp();
+
+      return () => {
+        window.removeEventListener('load', scaleApp);
+        window.removeEventListener('resize', scaleApp);
+        document.removeEventListener('gesturestart', preventGesture);
+        document.removeEventListener('gesturechange', preventGesture);
+      };
     }
   }, []);
 


### PR DESCRIPTION
## Summary
Same fix as jamiepates.com: pinch-zooming on mobile made the content glitch out and disappear, because `scaleApp` recomputes from `window.innerWidth/innerHeight`, which track the shrinking visual viewport mid-gesture on iOS.

- `scaleApp` now reads `document.documentElement.clientWidth/clientHeight` (the layout viewport, stable while pinching), so the zoom level can never react to a pinch
- Pinch zoom is blocked via `gesturestart`/`gesturechange` `preventDefault()` (iOS ignores `user-scalable=no`), double-tap zoom via `touch-action: manipulation`, and the viewport meta gains `maximum-scale=1, user-scalable=no` for Android, which does honour it
- The scale listeners now clean up on unmount

## Test plan
- [x] Emulated iPhone 15 Pro Max (WebKit): app scales to fit (zoom 0.45) and renders correctly
- [x] Desktop viewport: zoom 1.2, unchanged from before
- [x] `npm run lint` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)