### PR TITLE
Add cookieless analytics, kept out of the repository

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Umami website ID, from the tracking code panel in the Umami dashboard.
+#
+# Copy this file to .env.production.local and paste the ID in. That file is
+# gitignored, and `next build` inlines the value into the exported HTML — so the
+# ID never enters the repository.
+#
+# Leave it empty, or skip the file entirely, and analytics are a no-op: no script
+# tag, no requests. That is what a fork gets.
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/app/analytics.tsx
+++ b/src/app/analytics.tsx
@@ -1,0 +1,23 @@
+/**
+ * Umami, rendered only when a website ID was built in.
+ *
+ * The ID comes from `.env.production.local`, which is gitignored, so a clone or
+ * a fork renders no script tag at all — analytics are simply absent rather than
+ * broken or pointed at someone else's account. See `.env.example`.
+ *
+ * `NEXT_PUBLIC_*` values are inlined at build time, and this project is a static
+ * export, so the tag either is or is not in the exported HTML. Nothing is
+ * decided at runtime.
+ *
+ * Umami is cookieless, which is why the site carries no consent banner.
+ */
+export function Analytics() {
+    const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+
+    if (!websiteId) return null;
+
+    // A plain tag rather than next/script: the tracker reads its configuration
+    // off document.currentScript, and this way it is in the exported HTML with
+    // no client-side JavaScript involved at all.
+    return <script defer src="https://cloud.umami.is/script.js" data-website-id={websiteId} />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "./styles/font.css";
+import { Analytics } from "./analytics";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no"></meta>
         <link rel="icon" type="image/x-icon" href="/assets/cardicon.gif"></link>
+        <Analytics />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}


### PR DESCRIPTION
Traffic and referrer stats, using **Umami** rather than Google Analytics: it
sets no cookies, so no consent banner is needed. Matches the setup on
jamiepates.com and the other project sites.

### Nothing here reaches a fork

The website ID is read from `.env.production.local`, which is gitignored, and
the component renders `null` without it — so a fork produces no script tag, no
request and no ID. `NEXT_PUBLIC_*` is inlined at build time, so the tag either
is or is not in the output; nothing is decided at runtime.

A plain `<script>` rather than `next/script`, because the tracker reads its
configuration off `document.currentScript` and this way the tag sits in the
prerendered HTML with no client-side JavaScript involved.

`.gitignore` already had `.env*`, which would have swallowed the template, so
`.env.example` is now excepted.

## Testing

Built both ways and inspected the prerendered HTML:

- **No env file**: no `umami` anywhere in the output, and no tracker URL in the
  client bundle.
- **With an ID**: `<script defer src="https://cloud.umami.is/script.js"
  data-website-id="…">` present in the prerendered HTML.

Note this branch builds to `.next` rather than `out/` — `output: 'export'`
lives on `personal-branch`, not here, so `out/` in a working copy may be a
stale artefact from another branch.

## After merging

This needs to reach `personal-branch` to do anything, since that is what is
deployed. Then add the ID to `.env.production.local` there — **a separate one
from the other sites**, or the stats merge — and rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yxFHbQB5DPVd9cRZNW3A9